### PR TITLE
Fix yt-dlp format error by using flexible format selection

### DIFF
--- a/bot/handlers/commands.py
+++ b/bot/handlers/commands.py
@@ -13,7 +13,7 @@ router = Router()
 
 async def download_video(url: str) -> str:
     opts = {
-        "format": "bestvideo[ext=mp4][filesize<45M]+bestaudio[filesize<5M]/worstvideo[ext=mp4]+worstaudio",
+        "format": "bv*+ba/b",
         "merge-output-format": "mp4",
         "noplaylist": True,
         "quiet": True,


### PR DESCRIPTION
The previous format restrictions in download_video caused errors when requested formats were unavailable.
This update uses a more flexible format selection ("bv*+ba/b") to ensure the bot can download videos successfully
even if the specific format or size restrictions are not available.
